### PR TITLE
Return samples from TS.RANGE, patch TS.MADD for auto timestamps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,19 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     coderay (1.1.3)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
+    i18n (1.8.3)
+      concurrent-ruby (~> 1.0)
     method_source (1.0.0)
+    minitest (5.14.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -28,11 +38,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 6.0)
   bundler (~> 1.17)
   pry (~> 0.13)
   rake (~> 13.0)

--- a/bin/console
+++ b/bin/console
@@ -1,9 +1,19 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
+require 'active_support/core_ext/numeric/time'
 require 'pry'
 require 'redis-time-series'
 
 Redis.current.flushall
-@ts = Redis::TimeSeries.create('foo')
+
+@ts1 = Redis::TimeSeries.create('foo')
+@ts2 = Redis::TimeSeries.create('bar')
+@ts3 = Redis::TimeSeries.create('baz')
+
+@series = [@ts1, @ts2, @ts3]
+@series.each do |ts|
+  3.times { ts.increment }
+end
+
 Pry.start

--- a/lib/redis-time-series.rb
+++ b/lib/redis-time-series.rb
@@ -1,4 +1,5 @@
 require 'bigdecimal'
+require 'time/msec'
 require 'redis'
 require 'redis/time_series'
 require 'redis/time_series/sample'

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -74,10 +74,16 @@ class Redis
         args = values.first.map { |ts, val| [key, ts, val] }.flatten
       elsif values.one? && values.first.is_a?(Array)
         # Array of values, no timestamps
-        args = values.first.map { |val| [key, '*', val] }.flatten
+        initial_ts = Time.now.ts_msec
+        args = values.first.each_with_index.map do |val, idx|
+          [key, initial_ts + idx, val]
+        end.flatten
       else
         # Values as individual arguments, no timestamps
-        args = values.map { |val| [key, '*', val] }.flatten
+        initial_ts = Time.now.ts_msec
+        args = values.each_with_index.map do |val, idx|
+          [key, initial_ts + idx, val]
+        end.flatten
       end
       cmd 'TS.MADD', args
     end

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -91,7 +91,9 @@ class Redis
       args.map! { |ts| (ts.to_f * 1000).to_i }
       args.append('COUNT', count) if count
       # TODO: aggregations
-      cmd 'TS.RANGE', key, args
+      cmd('TS.RANGE', key, args).map do |ts, val|
+        Sample.new(ts, val)
+      end
     end
 
     def retention=(val)

--- a/lib/time/msec.rb
+++ b/lib/time/msec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class Time
+  # TODO: use refinemenets instead of monkey-patching Time
+  def ts_msec
+    (to_f * 1000.0).to_i
+  end
+end

--- a/redis-time-series.gemspec
+++ b/redis-time-series.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'redis', '~> 4.0'
 
+  spec.add_development_dependency 'activesupport', '~> 6.0'
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'pry', '~> 0.13'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -165,6 +165,15 @@ RSpec.describe Redis::TimeSeries do
     end
 
     context 'with an aggregation' # TODO
+
+    it 'returns an array of Samples' do
+      values = [2, 4, 6]
+      ts.madd values
+      results = ts.range(1.minute.ago..1.minute.from_now)
+      binding.pry
+      expect(results.size).to eq 3
+      expect(results.map(&:value)).to eq values
+    end
   end
 
   describe 'TS.MRANGE' # TODO: class method for querying multiple time-series

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -113,16 +113,28 @@ RSpec.describe Redis::TimeSeries do
     end
 
     context 'with an array of values' do
+      let(:time) { Time.now }
+      let(:ts_msec) { time.to_i * 1000 }
+
+      before { travel_to time } # TODO: freeze_time metadata
+      after { travel_back }
+
       specify do
         expect { ts.madd [56, 78, 9] }.to issue_command \
-          "TS.MADD #{key} * 56 #{key} * 78 #{key} * 9"
+          "TS.MADD #{key} #{ts_msec} 56 #{key} #{ts_msec + 1} 78 #{key} #{ts_msec + 2} 9"
       end
     end
 
     context 'passed values directly' do
+      let(:time) { Time.now }
+      let(:ts_msec) { time.to_i * 1000 }
+
+      before { travel_to time }
+      after { travel_back }
+
       specify do
         expect { ts.madd 1, 2, 3 }.to issue_command \
-          "TS.MADD #{key} * 1 #{key} * 2 #{key} * 3"
+          "TS.MADD #{key} #{ts_msec} 1 #{key} #{ts_msec + 1} 2 #{key} #{ts_msec + 2} 3"
       end
     end
   end
@@ -170,7 +182,6 @@ RSpec.describe Redis::TimeSeries do
       values = [2, 4, 6]
       ts.madd values
       results = ts.range(1.minute.ago..1.minute.from_now)
-      binding.pry
       expect(results.size).to eq 3
       expect(results.map(&:value)).to eq values
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'active_support/core_ext/numeric/time'
 require 'pry'
 require 'redis-time-series'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'active_support/core_ext/numeric/time'
+require 'active_support/testing/time_helpers'
 require 'pry'
 require 'redis-time-series'
 
@@ -13,6 +14,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 RSpec::Matchers.define :issue_command do |expected|


### PR DESCRIPTION
Main goal here was to return an array of sample objects from the `TS.RANGE` command. 

While working on that, I came across an edge case that wasn't clear in the docs - when using `TS.MADD` to add multiple values in one call, automatic timestamping only works with multiple series, e.g. `TS.MADD foo * 123 bar * 456`. When called with multiple values for the same series, only the first one would be added, and the following values would return a command error.

Discussed with one of the maintainers in https://github.com/RedisTimeSeries/RedisTimeSeries/issues/426, it sounds like this is an area being actively worked on. For now, I've chosen to automatically inject timestamps when adding multiple values to a series, incrementing each by 1ms.

Honestly not sure if this will be a common use case, or relevant at all, but it's very helpful for setting up test data when you don't really care about the precise timestamps.

Also monkey-patched `Time` to easily return integer millisecond timestamps - bad! Fix this at some point!