### PR TITLE
Add `Redis::TimeSeries::Info` struct and delegate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+* Converted `#info` to a struct instead of a hash.
+* Added methods on time series for getting info attributes.
+
 ## 0.1.1
 Fix setting labels on `TS.CREATE` and `TS.ALTER`
 

--- a/README.md
+++ b/README.md
@@ -133,16 +133,31 @@ ts.range from: 10.minutes.ago, to: Time.current # Time range as keyword args
 Get info about the series
 ```ruby
 ts.info
-=> {"total_samples"=>3,
- "memory_usage"=>4184,
- "first_timestamp"=>1593155422582,
- "last_timestamp"=>1593155709333,
- "retention_time"=>0,
- "chunk_count"=>1,
- "max_samples_per_chunk"=>256,
- "labels"=>[],
- "source_key"=>nil,
- "rules"=>[]}
+=> #<struct Redis::TimeSeries::Info
+ total_samples=3,
+ memory_usage=4184,
+ first_timestamp=1594060993011,
+ last_timestamp=1594060993060,
+ retention_time=0,
+ chunk_count=1,
+ max_samples_per_chunk=256,
+ labels={"foo"=>"bar"},
+ source_key=nil,
+ rules=[]>
+# Each info property is also a method on the time series object
+ts.memory_usage
+=> 4208
+ts.labels
+=> {"foo"=>"bar"}
+ts.total_samples
+=> 3
+# Total samples also available as #count, #length, and #size
+ts.count
+=> 3
+ts.length
+=> 3
+ts.size
+=> 3
 ```
 
 ### TODO

--- a/bin/console
+++ b/bin/console
@@ -14,7 +14,7 @@ Redis.current.flushall
 
 @series = [@ts1, @ts2, @ts3]
 @series.each do |ts|
-  3.times { ts.increment }
+  3.times { ts.increment; sleep 0.01 }
 end
 
 Pry.start

--- a/lib/redis-time-series.rb
+++ b/lib/redis-time-series.rb
@@ -1,5 +1,7 @@
 require 'bigdecimal'
+require 'forwardable'
 require 'time/msec'
+require 'redis/time_series/info'
 require 'redis/time_series'
 require 'redis/time_series/sample'
 

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -97,8 +97,7 @@ class Redis
       cmd('TS.INFO', key).then(&Info.method(:parse))
     end
     def_delegators :info, *Info.members
-    def_delegator :info, :total_samples, :count
-    def_delegator :info, :total_samples, :size
+    %i[count length size].each { |m| def_delegator :info, :total_samples, m }
 
     def labels=(val)
       @labels = val

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -5,7 +5,7 @@ class Redis
 
     class << self
       def create(key, **options)
-        new(key, **options).create
+        new(key, **options).create(labels: options[:labels])
       end
 
       def madd(data)
@@ -46,8 +46,6 @@ class Redis
 
     def initialize(key, options = {})
       @key = key
-      # TODO: read labels from redis if not loaded in memory
-      @labels = options[:labels] || []
       @redis = options[:redis] || self.class.redis
       @retention = options[:retention]
       @uncompressed = options[:uncompressed] || false
@@ -59,11 +57,11 @@ class Redis
       Sample.new(ts, value)
     end
 
-    def create
+    def create(labels: nil)
       args = [key]
       args << ['RETENTION', retention] if retention
       args << 'UNCOMPRESSED' if uncompressed
-      args << ['LABELS', @labels.to_a] if @labels.any?
+      args << ['LABELS', labels.to_a] if labels&.any?
       cmd 'TS.CREATE', args.flatten
       self
     end
@@ -100,8 +98,7 @@ class Redis
     %i[count length size].each { |m| def_delegator :info, :total_samples, m }
 
     def labels=(val)
-      @labels = val
-      cmd 'TS.ALTER', key, 'LABELS', @labels.to_a.flatten
+      cmd 'TS.ALTER', key, 'LABELS', val.to_a.flatten
     end
 
     def madd(*values)

--- a/lib/redis/time_series/info.rb
+++ b/lib/redis/time_series/info.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+class Redis
+  class TimeSeries
+    Info = Struct.new(
+      :total_samples,
+      :memory_usage,
+      :first_timestamp,
+      :last_timestamp,
+      :retention_time,
+      :chunk_count,
+      :max_samples_per_chunk,
+      :labels,
+      :source_key,
+      :rules,
+      keyword_init: true
+    ) do
+      def self.parse(raw_array)
+        raw_array.each_slice(2).reduce({}) do |h, (key, value)|
+          # Convert camelCase info keys to snake_case
+          h[key.gsub(/(.)([A-Z])/,'\1_\2').downcase] = value
+          h
+        end.then do |parsed_hash|
+          parsed_hash['labels'] = parsed_hash['labels'].to_h
+          new(parsed_hash)
+        end
+      end
+    end
+  end
+end

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe Redis::TimeSeries do
 
       specify do
         expect { create }.to issue_command "TS.CREATE #{key} LABELS foo bar baz 1 plugh true"
-        expect(ts.info['labels']).to eq [
+        expect(ts.labels).to eq(
+          'foo' => 'bar',
           # TODO: cast values
-          ['foo', 'bar'],
-          ['baz', '1'],
-          ['plugh', 'true']
-        ]
+          'baz' => '1',
+          'plugh' => 'true'
+        )
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe Redis::TimeSeries do
       specify do
         expect { ts.labels = { foo: 'bar' } }.to issue_command \
           "TS.ALTER #{key} LABELS foo bar"
-        expect(ts.info['labels']).to eq [['foo', 'bar']]
+        expect(ts.labels).to eq('foo' => 'bar')
       end
     end
   end
@@ -240,21 +240,37 @@ RSpec.describe Redis::TimeSeries do
 
     specify { expect { info }.to issue_command "TS.INFO #{key}" }
 
-    it 'returns an info hash' do
-      expect(info).to eq(
+    it 'returns an info struct' do
+      expect(info).to be_a Redis::TimeSeries::Info
+      expect(info.to_h).to eq(
         {
-          'total_samples' => 0,
-          'memory_usage' => 4184,
-          'first_timestamp' => 0,
-          'last_timestamp' => 0,
-          'retention_time' => 0,
-          'chunk_count' => 1,
-          'max_samples_per_chunk' => 256,
-          'labels' => [],
-          'source_key' => nil,
-          'rules' => []
+          total_samples: 0,
+          memory_usage: 4184,
+          first_timestamp: 0,
+          last_timestamp: 0,
+          retention_time: 0,
+          chunk_count: 1,
+          max_samples_per_chunk: 256,
+          labels: {},
+          source_key: nil,
+          rules: []
         }
       )
+    end
+
+    Redis::TimeSeries::Info.members.each do |member|
+      it "delegates ##{member} to #info" do
+        expect(ts).to respond_to member
+        expect(ts.public_send(member)).to eq ts.info.public_send(member)
+      end
+    end
+
+    it 'delegates #total_samples as #count' do
+      expect(ts.count).to eq ts.info.total_samples
+    end
+
+    it 'delegates #total_samples as #size' do
+      expect(ts.size).to eq ts.info.total_samples
     end
   end
 

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -269,6 +269,10 @@ RSpec.describe Redis::TimeSeries do
       expect(ts.count).to eq ts.info.total_samples
     end
 
+    it 'delegates #total_samples as #length' do
+      expect(ts.length).to eq ts.info.total_samples
+    end
+
     it 'delegates #total_samples as #size' do
       expect(ts.size).to eq ts.info.total_samples
     end


### PR DESCRIPTION
Rather than returning a raw hash, `TimeSeries#info` will now return a `Redis::TimeSeries::Info` struct with members for each info attribute. Method access for each attribute is also available on the `TimeSeries` object.

In addition to extracting the parse logic from the main `TimeSeries` class, this also makes it easy to "alias" info methods via delegation. For example, `#total_samples` is aliased as `#count`, `#length`, and `#size`, similar to how you'd get the size of an array in Ruby.

In the future, it would be nice to convert `first_timestamp` and `last_timestamp` to `Time` objects instead of integers.