### PR TITLE
Add hash-based filter DSL

### DIFF
--- a/lib/redis-time-series.rb
+++ b/lib/redis-time-series.rb
@@ -1,7 +1,7 @@
 require 'bigdecimal'
 require 'forwardable'
 require 'time/msec'
-require 'redis/time_series/filter'
+require 'redis/time_series/filters'
 require 'redis/time_series/info'
 require 'redis/time_series/sample'
 require 'redis/time_series'

--- a/lib/redis-time-series.rb
+++ b/lib/redis-time-series.rb
@@ -1,6 +1,7 @@
 require 'bigdecimal'
 require 'forwardable'
 require 'time/msec'
+require 'redis/time_series/errors'
 require 'redis/time_series/filters'
 require 'redis/time_series/info'
 require 'redis/time_series/sample'

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -34,7 +34,7 @@ class Redis
       end
 
       def queryindex(filter_value)
-        filters = Filter.new(filter_value)
+        filters = Filters.new(filter_value)
         filters.validate!
         redis.call('TS.QUERYINDEX', *filters.to_a).map { |key| new(key) }
       end

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -36,8 +36,10 @@ class Redis
       def queryindex(filter_value)
         filters = Filters.new(filter_value)
         filters.validate!
+        puts "DEBUG: TS.QUERYINDEX #{filters.to_a.join(' ')}" if ENV['DEBUG']
         redis.call('TS.QUERYINDEX', *filters.to_a).map { |key| new(key) }
       end
+      alias where queryindex
 
       def redis
         @redis ||= Redis.current

--- a/lib/redis/time_series/errors.rb
+++ b/lib/redis/time_series/errors.rb
@@ -1,0 +1,10 @@
+class Redis
+  class TimeSeries
+    # Base error class for convenient `rescue`ing
+    class Error < StandardError; end
+
+    # Invalid filter error is raised when attempting to filter without at least
+    # one equality comparison ("foo=bar")
+    class InvalidFilters < Error; end
+  end
+end

--- a/lib/redis/time_series/filters.rb
+++ b/lib/redis/time_series/filters.rb
@@ -9,6 +9,10 @@ class Redis
           new(*str.split('='))
         end
 
+        def to_h
+          { label => value }
+        end
+
         def to_s
           "#{label}=#{value}"
         end
@@ -19,6 +23,10 @@ class Redis
 
         def self.parse(str)
           new(*str.split('!='))
+        end
+
+        def to_h
+          { label => { not: value } }
         end
 
         def to_s
@@ -33,6 +41,10 @@ class Redis
           new(str.delete('='))
         end
 
+        def to_h
+          { label => false }
+        end
+
         def to_s
           "#{label}="
         end
@@ -43,6 +55,10 @@ class Redis
 
         def self.parse(str)
           new(str.delete('!='))
+        end
+
+        def to_h
+          { label => true }
         end
 
         def to_s
@@ -59,6 +75,10 @@ class Redis
           new(label, values)
         end
 
+        def to_h
+          { label => values }
+        end
+
         def to_s
           "#{label}=(#{values.join(',')})"
         end
@@ -71,6 +91,10 @@ class Redis
           label, values = str.split('!=')
           values = values.tr('()', '').split(',')
           new(label, values)
+        end
+
+        def to_h
+          { label => { not: values } }
         end
 
         def to_s
@@ -88,11 +112,10 @@ class Redis
       attr_reader :filters
 
       def initialize(filters = nil)
-        #return @filters = parse_string(filters) || {}
         @filters = case filters
                    when String then parse_string(filters)
                    when Hash then parse_hash(filters)
-                   else {}
+                   else []
                    end
       end
 
@@ -106,6 +129,14 @@ class Redis
 
       def to_a
         filters.map(&:to_s)
+      end
+
+      def to_h
+        filters.reduce({}) { |h, filter| h.merge(filter.to_h) }
+      end
+
+      def to_s
+        to_a.join(' ')
       end
 
       private

--- a/lib/redis/time_series/filters.rb
+++ b/lib/redis/time_series/filters.rb
@@ -80,7 +80,7 @@ class Redis
         end
 
         def to_s
-          "#{label}=(#{values.join(',')})"
+          "#{label}=(#{values.map(&:to_s).join(',')})"
         end
       end
 
@@ -98,7 +98,7 @@ class Redis
         end
 
         def to_s
-          "#{label}!=(#{values.join(',')})"
+          "#{label}!=(#{values.map(&:to_s).join(',')})"
         end
       end
 

--- a/lib/redis/time_series/filters.rb
+++ b/lib/redis/time_series/filters.rb
@@ -120,7 +120,7 @@ class Redis
       end
 
       def validate!
-        valid? || raise('Filtering requires at least one equality comparison')
+        valid? || raise(InvalidFilters, 'Filtering requires at least one equality comparison')
       end
 
       def valid?
@@ -145,7 +145,7 @@ class Redis
         return unless filter_string.is_a? String
         filter_string.split(' ').map do |str|
           match = TYPES.find { |f| f::REGEX.match? str }
-          raise "Unable to parse '#{str}'" unless match
+          raise(InvalidFilters, "Unable to parse '#{str}'") unless match
           match.parse(str)
         end
       end
@@ -158,7 +158,7 @@ class Redis
           when FalseClass then Absent.new(label)
           when Array then AnyValue.new(label, value)
           when Hash
-            raise 'Invalid filter hash value' unless value.keys === [:not]
+            raise(InvalidFilters, "Invalid filter hash value #{value}") unless value.keys === [:not]
             (v = value.values.first).is_a?(Array) ? NoValues.new(label, v) : NotEqual.new(label, v)
           else Equal.new(label, value)
           end

--- a/spec/redis/time_series/errors_spec.rb
+++ b/spec/redis/time_series/errors_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe 'Errors' do
+  let(:base_error_class) { Redis::TimeSeries::Error }
+
+  describe Redis::TimeSeries::Error do
+    it 'exists' do
+      expect(described_class).to be
+    end
+
+    it { is_expected.to be_a StandardError }
+  end
+
+  describe Redis::TimeSeries::InvalidFilters do
+    it 'exists' do
+      expect(described_class).to be
+    end
+
+    it { is_expected.to be_a base_error_class }
+  end
+end

--- a/spec/redis/time_series/filters_spec.rb
+++ b/spec/redis/time_series/filters_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-RSpec.describe Redis::TimeSeries::Filter do
-  subject(:filter) { described_class.new(filter_string) }
+RSpec.describe Redis::TimeSeries::Filters do
+  subject(:filters) { described_class.new(value) }
 
-  let(:filter_string) { 'foo=bar baz!=quux plugh= xyzzy!= zork=(grue,cyclops) barrow!=(wizard,frobozz)' }
+  let(:value) { 'foo=bar baz!=quux plugh= xyzzy!= zork=(grue,cyclops) barrow!=(wizard,frobozz)' }
 
   shared_examples 'parsing and serialization' do |expected_string|
     it 'correctly parses' do
@@ -17,57 +17,57 @@ RSpec.describe Redis::TimeSeries::Filter do
   end
 
   context 'equality filter' do
-    subject(:filters) { filter.equal_filters }
+    let(:filters) { super().equal }
 
     include_examples 'parsing and serialization', 'foo=bar'
   end
 
   context 'inequality filter' do
-    subject(:filters) { filter.not_equal_filters }
+    let(:filters) { super().not_equal }
 
     include_examples 'parsing and serialization', 'baz!=quux'
   end
 
 
   context 'absence filter' do
-    subject(:filters) { filter.absent_filters }
+    let(:filters) { super().absent }
 
     include_examples 'parsing and serialization', 'plugh='
   end
 
   context 'presence filter' do
-    subject(:filters) { filter.present_filters }
+    let(:filters) { super().present }
 
     include_examples 'parsing and serialization', 'xyzzy!='
   end
 
   context 'any value filter' do
-    subject(:filters) { filter.any_value_filters }
+    let(:filters) { super().any_value }
 
     include_examples 'parsing and serialization', 'zork=(grue,cyclops)'
   end
 
   context 'no values filter' do
-    subject(:filters) { filter.no_values_filters }
+    let(:filters) { super().no_values }
 
     include_examples 'parsing and serialization', 'barrow!=(wizard,frobozz)'
   end
 
   describe '#valid?' do
     context 'with at least one equality filter' do
-      let(:filter_string) { 'foo=bar' }
+      let(:value) { 'foo=bar' }
 
       it { is_expected.to be_valid }
     end
 
     context 'with no equality filter' do
-      let(:filter_string) { 'foo!=bar baz=' }
+      let(:value) { 'foo!=bar baz=' }
 
       it { is_expected.not_to be_valid }
     end
 
     context 'with no filters' do
-      let(:filter_string) { nil }
+      let(:value) { nil }
 
       it { is_expected.not_to be_valid }
     end
@@ -75,26 +75,26 @@ RSpec.describe Redis::TimeSeries::Filter do
 
   describe '#validate!' do
     context 'when valid' do
-      let(:filter_string) { 'foo=bar' }
+      let(:value) { 'foo=bar' }
 
       it 'returns true' do
-        expect(filter.validate!).to be true
+        expect(filters.validate!).to be true
       end
     end
 
     context 'when invalid' do
-      let(:filter_string) { nil }
+      let(:value) { nil }
 
       it 'raises an error' do
         # TODO: custom error class
-        expect { filter.validate! }.to raise_error RuntimeError
+        expect { filters.validate! }.to raise_error RuntimeError
       end
     end
   end
 
   describe '#to_a' do
     it 'returns the parsed filters as an array of strings' do
-      expect(filter.to_a).to match_array filter_string.split(' ')
+      expect(filters.to_a).to match_array value.split(' ')
     end
   end
 end

--- a/spec/redis/time_series/filters_spec.rb
+++ b/spec/redis/time_series/filters_spec.rb
@@ -4,15 +4,42 @@ require 'spec_helper'
 RSpec.describe Redis::TimeSeries::Filters do
   subject(:filters) { described_class.new(value) }
 
-  let(:value) { 'foo=bar baz!=quux plugh= xyzzy!= zork=(grue,cyclops) barrow!=(wizard,frobozz)' }
+  let(:value) { string_value }
+  let(:string_value) { 'foo=bar baz!=quux plugh= xyzzy!= zork=(grue,cyclops) barrow!=(wizard,frobozz)' }
+  let(:hash_value) do
+    {
+      foo: 'bar',
+      baz: { not: 'quux' },
+      plugh: false,
+      xyzzy: true,
+      zork: ['grue', 'cyclops'],
+      barrow: { not: ['wizard', 'frobozz'] }
+    }
+  end
 
   shared_examples 'parsing and serialization' do |expected_string|
-    it 'correctly parses' do
-      expect(filters.size).to eq 1
+    context 'with a string' do
+      let(:value) { string_value }
+
+      it 'correctly parses' do
+        expect(filters.size).to eq 1
+      end
+
+      it 'correctly serializes' do
+        expect(filters.map(&:to_s)).to contain_exactly expected_string
+      end
     end
 
-    it 'correctly serializes' do
-      expect(filters.map(&:to_s)).to contain_exactly expected_string
+    context 'with a hash' do
+      let(:value) { hash_value }
+
+      it 'correctly parses' do
+        expect(filters.size).to eq 1
+      end
+
+      it 'correctly serializes' do
+        expect(filters.map(&:to_s)).to contain_exactly expected_string
+      end
     end
   end
 

--- a/spec/redis/time_series/filters_spec.rb
+++ b/spec/redis/time_series/filters_spec.rb
@@ -113,8 +113,7 @@ RSpec.describe Redis::TimeSeries::Filters do
       let(:value) { nil }
 
       it 'raises an error' do
-        # TODO: custom error class
-        expect { filters.validate! }.to raise_error RuntimeError
+        expect { filters.validate! }.to raise_error Redis::TimeSeries::InvalidFilters
       end
     end
   end
@@ -138,6 +137,20 @@ RSpec.describe Redis::TimeSeries::Filters do
 
     it 'returns the parsed filters as a single string' do
       expect(filters.to_s).to eq string_value
+    end
+  end
+
+  describe 'errors' do
+    context 'when given an invalid filter string' do
+      let(:value) { 'foo' }
+
+      specify { expect { filters }.to raise_error Redis::TimeSeries::InvalidFilters }
+    end
+
+    context 'when given an invalid hash value' do
+      let(:value) { { foo: { bar: 'baz' } } }
+
+      specify { expect { filters }.to raise_error Redis::TimeSeries::InvalidFilters }
     end
   end
 end

--- a/spec/redis/time_series/filters_spec.rb
+++ b/spec/redis/time_series/filters_spec.rb
@@ -124,4 +124,20 @@ RSpec.describe Redis::TimeSeries::Filters do
       expect(filters.to_a).to match_array value.split(' ')
     end
   end
+
+  describe '#to_h' do
+    let(:value) { string_value }
+
+    it 'returns the parsed filters as a hash' do
+      expect(filters.to_h).to eq hash_value.transform_keys(&:to_s)
+    end
+  end
+
+  describe '#to_s' do
+    let(:value) { hash_value }
+
+    it 'returns the parsed filters as a single string' do
+      expect(filters.to_s).to eq string_value
+    end
+  end
 end

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -303,8 +303,7 @@ RSpec.describe Redis::TimeSeries do
       let(:filters) { 'foo!=bar' }
 
       it 'raises an error' do
-        # TODO: custom error class
-        expect { result }.to raise_error RuntimeError
+        expect { result }.to raise_error Redis::TimeSeries::InvalidFilters
       end
     end
 

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -308,10 +308,24 @@ RSpec.describe Redis::TimeSeries do
       end
     end
 
-    it 'returns matching time series' do
-      expect(result.size).to eq 1
-      expect(result.first).to be_a described_class
-      expect(result.first.key).to eq 'good'
+    context 'with a hash of filters' do
+      let(:filters) { { foo: 'bar' } }
+
+      it 'returns matching time series' do
+        expect(result.size).to eq 1
+        expect(result.first).to be_a described_class
+        expect(result.first.key).to eq 'good'
+      end
+    end
+
+    context 'with a filter string' do
+      let(:filters) { 'foo=bar' }
+
+      it 'returns matching time series' do
+        expect(result.size).to eq 1
+        expect(result.first).to be_a described_class
+        expect(result.first.key).to eq 'good'
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #7. You can now filter by hash in addition to the raw string values.

Also added a `.where` alias for the `queryindex` command for a more fluent interface.

```ruby
class House
  attr_accessor :id

  def temperatures
    Redis::TimeSeries.where(type: 'thermostat', house_id: id).map(&:get)
  end
end
```