### PR TITLE
Extract client handling into Client module

### DIFF
--- a/lib/redis-time-series.rb
+++ b/lib/redis-time-series.rb
@@ -1,6 +1,7 @@
 require 'bigdecimal'
 require 'forwardable'
 require 'ext/time_msec'
+require 'redis/time_series/client'
 require 'redis/time_series/errors'
 require 'redis/time_series/aggregation'
 require 'redis/time_series/filters'

--- a/lib/redis/time_series/client.rb
+++ b/lib/redis/time_series/client.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+class Redis
+  class TimeSeries
+    module Client
+      def self.extended(base)
+        base.class_eval do
+          attr_accessor :redis
+
+          private
+
+          def cmd(name, *args)
+            self.class.send :cmd_with_redis, redis, name, *args
+          end
+        end
+      end
+
+      def debug
+        @debug.nil? ? [true, 'true', 1].include?(ENV['DEBUG']) : @debug
+      end
+
+      def debug=(bool)
+        @debug = !!bool
+      end
+
+      def redis
+        @redis ||= Redis.current
+      end
+
+      def redis=(client)
+        @redis = client
+      end
+
+      private
+
+      def cmd(name, *args)
+        cmd_with_redis redis, name, *args
+      end
+
+      def cmd_with_redis(redis, name, *args)
+        args = args.flatten.compact.map { |arg| arg.is_a?(Time) ? arg.ts_msec : arg }
+        puts "DEBUG: #{name} #{args.join(' ')}" if debug
+        redis.call name, args
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #22 

Extracted class and instance-level management of the Redis client object into a new `Client` module. The client still defaults to `Redis.current`, which can be overridden at the class-level for all time series, or provided as an option to the instance for only one series.

Moved argument parsing into the `Client` module. Args passed to the `cmd` call will be automatically `flatten`ed, `compact`ed, and have Time objects converted to their millisecond timestamp representation. This cleans up a lot of repetitive code at the call sites, and also means that `cmd` can be called with positional arguments, eliminating an intermediate `args` array. 

Note that the class-level methods like `.query_index` can only use the class-level client.

Removed the `@retention` and `@uncompressed` instance variables.
* They could be inaccurate if you instantiated a new object without calling `.create`
* Retention information is available in the `.info` hash
* See #31 for pending changes to `UNCOMPRESSED`