### PR TITLE
Fix aggregations for TS.RANGE command

### DIFF
--- a/lib/redis/time_series/aggregation.rb
+++ b/lib/redis/time_series/aggregation.rb
@@ -23,6 +23,7 @@ class Redis
       alias time_bucket duration
 
       def self.parse(agg)
+        return unless agg
         return agg if agg.is_a?(self)
         return new(agg.first, agg.last) if agg.is_a?(Array) && agg.size == 2
         raise AggregationError, "Couldn't parse #{agg} into an aggregation rule!"
@@ -33,7 +34,11 @@ class Redis
           raise AggregationError, "#{type} is not a valid aggregation type!"
         end
         @type = type.to_s
-        @duration = duration.to_i
+        if defined?(ActiveSupport::Duration) && duration.is_a?(ActiveSupport::Duration)
+          @duration = duration.to_i * 1000
+        else
+          @duration = duration.to_i
+        end
       end
 
       def to_a

--- a/lib/redis/time_series/aggregation.rb
+++ b/lib/redis/time_series/aggregation.rb
@@ -35,7 +35,7 @@ class Redis
         end
         @type = type.to_s
         if defined?(ActiveSupport::Duration) && duration.is_a?(ActiveSupport::Duration)
-          @duration = duration.to_i * 1000
+          @duration = duration.in_milliseconds
         else
           @duration = duration.to_i
         end

--- a/lib/redis/time_series/client.rb
+++ b/lib/redis/time_series/client.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+using TimeMsec
+
 class Redis
   class TimeSeries
     module Client

--- a/spec/redis/time_series/aggregation_spec.rb
+++ b/spec/redis/time_series/aggregation_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Redis::TimeSeries::Aggregation do
       it { is_expected.to eq described_class.new(:min, 1234) }
     end
 
+    context 'given nil' do
+      let(:raw) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
     context 'anything else' do
       let(:raw) { 'foo' }
 
@@ -38,6 +44,12 @@ RSpec.describe Redis::TimeSeries::Aggregation do
 
     context 'given an invalid type' do
       specify { expect { described_class.new('foo', 123) }.to raise_error Redis::TimeSeries::AggregationError }
+    end
+
+    context 'given an ActiveSupport::Duration' do
+      it 'converts it to milliseconds' do
+        expect(described_class.new(:avg, 15.minutes).duration).to eq 900000
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #28 

Also added support for providing an `ActiveSupport::Duration` as an aggregation bucket. I feel like it might be bad practice to hardcode type-checks for an external library like this, but honestly, Rails is popular enough, and if you're working with time series data, the sugar from AS::D `10.minutes` et. al. is super useful.