### PR TITLE
Add `uncompressed` param to TS.ADD, TS.INCRBY, TS.DECRBY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Fix aggregations for TS.RANGE command (#34)
 * Extract client handling into Client module (#32)
+* Add `uncompressed` param to TS.ADD, TS.INCRBY, TS.DECRBY (#35)
 
 ## 0.4.0
 * Added [hash-based filter DSL](https://github.com/dzunk/redis-time-series/tree/7173c73588da50614c02f9c89bf2ecef77766a78#filter-dsl)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Add a single value with a timestamp
 ```ruby
 ts.add 1234, 3.minutes.ago # Used ActiveSupport here, but any Time object works fine
 => #<Redis::TimeSeries::Sample:0x00007fa6ce05f3f8 @time=2020-06-25 23:39:54 -0700, @value=0.1234e4>
+
+# Optionally store data uncompressed
+ts.add 5678, uncompressed: true
+=> #<Redis::TimeSeries::Sample:0x00007f93f43cdf68 @time=2020-07-18 23:15:29 -0700, @value=0.5678e4>
 ```
 Add multiple values with timestamps
 ```ruby
@@ -89,6 +93,10 @@ ts.increment # alias of incrby
 => 1593154255069
 ts.decrement # alias of decrby
 => 1593154257344
+
+# Optionally store data uncompressed
+ts.incrby 4, uncompressed: true
+=> 1595139299769
 ```
 ```ruby
 ts.get

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -70,8 +70,8 @@ class Redis
       @redis = redis
     end
 
-    def add(value, timestamp = '*')
-      ts = cmd 'TS.ADD', key, timestamp, value
+    def add(value, timestamp = '*', uncompressed: nil)
+      ts = cmd 'TS.ADD', key, timestamp, value, ('UNCOMPRESSED' if uncompressed)
       Sample.new(ts, value)
     end
 
@@ -91,8 +91,8 @@ class Redis
       self.class.delete_rule(source: self, dest: dest)
     end
 
-    def decrby(value = 1, timestamp = nil)
-      cmd 'TS.DECRBY', key, value, (timestamp if timestamp)
+    def decrby(value = 1, timestamp = nil, uncompressed: nil)
+      cmd 'TS.DECRBY', key, value, (timestamp if timestamp), ('UNCOMPRESSED' if uncompressed)
     end
     alias decrement decrby
 
@@ -107,8 +107,8 @@ class Redis
       end
     end
 
-    def incrby(value = 1, timestamp = nil)
-      cmd 'TS.INCRBY', key, value, (timestamp if timestamp)
+    def incrby(value = 1, timestamp = nil, uncompressed: nil)
+      cmd 'TS.INCRBY', key, value, (timestamp if timestamp), ('UNCOMPRESSED' if uncompressed)
     end
     alias increment incrby
 

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -110,6 +110,10 @@ RSpec.describe Redis::TimeSeries do
       specify { expect { ts.add 'bar' }.to raise_error Redis::CommandError }
     end
 
+    context 'with uncompressed: true' do
+      specify { expect { ts.add 123, uncompressed: true }.to issue_command "TS.ADD #{key} * 123 UNCOMPRESSED" }
+    end
+
     it 'returns the added Sample' do
       s = ts.add 123
       expect(s).to be_a Redis::TimeSeries::Sample
@@ -179,6 +183,10 @@ RSpec.describe Redis::TimeSeries do
     context 'with a timestamp' do
       specify { expect { ts.incrby 1, time }.to issue_command "TS.INCRBY #{key} 1 #{time}" }
     end
+
+    context 'with uncompressed: true' do
+      specify { expect { ts.incrby 1, uncompressed: true }.to issue_command "TS.INCRBY #{key} 1 UNCOMPRESSED" }
+    end
   end
 
   describe 'TS.DECRBY' do
@@ -186,6 +194,10 @@ RSpec.describe Redis::TimeSeries do
 
     context 'with a timestamp' do
       specify { expect { ts.decrby 1, time }.to issue_command "TS.DECRBY #{key} 1 #{time}" }
+    end
+
+    context 'with uncompressed: true' do
+      specify { expect { ts.decrby 1, uncompressed: true }.to issue_command "TS.DECRBY #{key} 1 UNCOMPRESSED" }
     end
   end
 


### PR DESCRIPTION
Closes #31

Adds optional `uncompressed: true` argument to `#add`, `#incrby`, and `#decrby` to store time series data in uncompressed format.