### PR TITLE
Add YARD documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Extract client handling into Client module (#32)
 * Add `uncompressed` param to TS.ADD, TS.INCRBY, TS.DECRBY (#35)
 * Add `Redis::TimeSeries::Rule` object (#38)
+* Add [YARD documentation](https://rubydoc.info/gems/redis-time-series) (#40)
 
 ## 0.4.0
 * Added [hash-based filter DSL](https://github.com/dzunk/redis-time-series/tree/7173c73588da50614c02f9c89bf2ecef77766a78#filter-dsl)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![RSpec](https://github.com/dzunk/redis-time-series/workflows/RSpec/badge.svg)](https://github.com/dzunk/redis-time-series/actions?query=workflow%3ARSpec+branch%3Amaster)
 [![Gem Version](https://badge.fury.io/rb/redis-time-series.svg)](https://badge.fury.io/rb/redis-time-series)
+[![Documentation](https://img.shields.io/badge/docs-rubydoc.info-brightgreen)](https://rubydoc.info/gems/redis-time-series)
 [![Maintainability](https://api.codeclimate.com/v1/badges/19a5925c20318508b4a4/maintainability)](https://codeclimate.com/github/dzunk/redis-time-series/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/19a5925c20318508b4a4/test_coverage)](https://codeclimate.com/github/dzunk/redis-time-series/test_coverage)
 

--- a/bin/setup
+++ b/bin/setup
@@ -3,10 +3,12 @@
 system 'bundle install'
 system 'docker pull redislabs/redistimeseries:latest'
 container_id = `docker run -p 6379:6379 -dit --rm redislabs/redistimeseries`
+at_exit { system "docker stop #{container_id}" }
 
 require 'bundler/setup'
 require 'active_support/core_ext/numeric/time'
 require 'redis'
+require 'redis-time-series'
 
 Redis.current.flushall
 ts1 = Redis::TimeSeries.create('ts1')
@@ -26,5 +28,4 @@ ts3.incrby 2
 sleep 0.01
 ts3.decrement
 
-at_exit { system "docker stop #{container_id}" }
 system "docker logs -f #{container_id}"

--- a/lib/ext/time_msec.rb
+++ b/lib/ext/time_msec.rb
@@ -1,8 +1,29 @@
 # frozen_string_literal: true
+
+# The +TimeMsec+ module is a refinement for the +Time+ class that makes it easier
+# to work with millisecond timestamps.
+#
+# @example
+#   Time.now.to_i    # 1595194259
+#   Time.now.ts_msec # NoMethodError
+#
+#   using TimeMsec
+#
+#   Time.now.to_i    # 1595194259
+#   Time.now.ts_msec # 1595194259000
+#
+#   Time.from_msec(1595194259000) # 2020-07-19 14:30:59 -0700
 module TimeMsec
   refine Time do
+    # TODO: convert to #to_msec
     def ts_msec
       (to_f * 1000.0).to_i
+    end
+  end
+
+  refine Time.singleton_class do
+    def from_msec(timestamp)
+      at(timestamp / 1000.0)
     end
   end
 end

--- a/lib/redis/time_series/aggregation.rb
+++ b/lib/redis/time_series/aggregation.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 class Redis
   class TimeSeries
+    # An aggregation is a combination of a mathematical function, and a time window over
+    # which to apply that function. In RedisTimeSeries, aggregations are used to downsample
+    # data from a source series to a destination series, using compaction rules.
+    #
+    # @see Redis::TimeSeries#create_rule
+    # @see Redis::TimeSeries::Rule
+    # @see https://oss.redislabs.com/redistimeseries/commands/#aggregation-compaction-downsampling
     class Aggregation
       TYPES = %w[
         avg
@@ -17,11 +24,20 @@ class Redis
         var.s
       ]
 
-      attr_reader :type, :duration
-
+      # @return [String] the type of aggregation to apply
+      # @see TYPES
+      attr_reader :type
       alias aggregation_type type
+
+      # @return [Integer] the time window to apply the aggregation over, in milliseconds
+      attr_reader :duration
       alias time_bucket duration
 
+      # Parse a method argument into an aggregation.
+      #
+      # @param agg [Array, Aggregation] an aggregation object, or an array of type and duration +[:avg, 60000]+
+      # @return [Aggregation] the parsed aggregation, or the original argument if already an aggregation
+      # @raise [AggregationError] when given an unparseable value
       def self.parse(agg)
         return unless agg
         return agg if agg.is_a?(self)
@@ -29,6 +45,13 @@ class Redis
         raise AggregationError, "Couldn't parse #{agg} into an aggregation rule!"
       end
 
+      # Create a new Aggregation given a type and duration.
+      # @param type [String, Symbol] one of the valid aggregation {TYPES}
+      # @param duration [Integer, ActiveSupport::Duration]
+      #   A time window to apply this aggregation over.
+      #   If you're using ActiveSupport, duration objects (e.g. +10.minutes+) will be automatically coerced.
+      # @return [Aggregation]
+      # @raise [AggregationError] if the given aggregation type is not valid
       def initialize(type, duration)
         type = type.to_s.downcase
         unless TYPES.include? type
@@ -42,14 +65,20 @@ class Redis
         end
       end
 
+      # @api private
+      # @return [Array]
       def to_a
         ['AGGREGATION', type, duration]
       end
 
+      # @api private
+      # @return [String]
       def to_s
         to_a.join(' ')
       end
 
+      # Compares aggregations based on type and duration.
+      # @return [Boolean] whether the given aggregations are equivalent
       def ==(other)
         parsed = self.class.parse(other)
         type == parsed.type && duration == parsed.duration

--- a/lib/redis/time_series/client.rb
+++ b/lib/redis/time_series/client.rb
@@ -3,10 +3,13 @@ using TimeMsec
 
 class Redis
   class TimeSeries
+    # The client module handles connection management for individual time series, and
+    # the parent {TimeSeries} class methods. You can enable or disable debugging, and set
+    # a default Redis client to use for time series objects.
     module Client
       def self.extended(base)
         base.class_eval do
-          attr_accessor :redis
+          attr_reader :redis
 
           private
 
@@ -16,18 +19,44 @@ class Redis
         end
       end
 
+      # Check debug status. Defaults to on with +DEBUG=true+ environment variable.
+      # @return [Boolean] current debug status
       def debug
         @debug.nil? ? [true, 'true', 1].include?(ENV['DEBUG']) : @debug
       end
 
+      # Enable or disable debug output for time series commands. Enabling debug will
+      # print commands to +STDOUT+ as they're executed.
+      #
+      # @example
+      #   [1] pry(main)> @ts1.get
+      #   => #<Redis::TimeSeries::Sample:0x00007fc82e9de150 @time=2020-07-19 15:01:13 -0700, @value=0.56e2>
+      #   [2] pry(main)> Redis::TimeSeries.debug = true
+      #   => true
+      #   [3] pry(main)> @ts1.get
+      #   DEBUG: TS.GET ts1
+      #    => #<Redis::TimeSeries::Sample:0x00007fc82f11b7b0 @time=2020-07-19 15:01:13 -0700, @value=0.56e2>
+      #
+      # @return [Boolean] new debug status
       def debug=(bool)
         @debug = !!bool
       end
 
+      # @return [Redis] the current Redis client. Defaults to +Redis.current+
       def redis
         @redis ||= Redis.current
       end
 
+      # Set the default Redis client for time series objects.
+      # This may be useful if you already use a non-time-series Redis database, and want
+      # to use both at the same time.
+      #
+      # @example
+      #   # config/initializers/redis_time_series.rb
+      #   Redis::TimeSeries.redis = Redis.new(url: 'redis://my-redis-server:6379/0')
+      #
+      # @param client [Redis] a Redis client
+      # @return [Redis]
       def redis=(client)
         @redis = client
       end

--- a/lib/redis/time_series/errors.rb
+++ b/lib/redis/time_series/errors.rb
@@ -1,13 +1,17 @@
 class Redis
   class TimeSeries
-    # Base error class for convenient `rescue`ing
-    class Error < StandardError; end
+    # Base error class for convenient +rescue+-ing.
+    #
+    # Descendant of +Redis::BaseError+, so you can rescue that and capture all
+    # time-series errors, as well as standard Redis command errors.
+    class Error < Redis::BaseError; end
 
-    # Invalid filter error is raised when attempting to filter without at least
-    # one equality comparison ("foo=bar")
+    # +FilterError+ is raised when a given set of filters is invalid (i.e. does not contain
+    # a equality comparison "foo=bar"), or the filter value is unparseable.
+    # @see Redis::TimeSeries::Filters
     class FilterError < Error; end
 
-    # Aggregation error is raised when attempting to create anaggreation with
+    # +AggregationError+ is raised when attempting to create an aggreation with
     # an unknown type, or when calling a command with an invalid aggregation value.
     # @see Redis::TimeSeries::Aggregation
     class AggregationError < Error; end

--- a/lib/redis/time_series/info.rb
+++ b/lib/redis/time_series/info.rb
@@ -1,20 +1,56 @@
 # frozen_string_literal: true
 class Redis
   class TimeSeries
+    # The Info struct wraps the result of the +TS.INFO+ command with method access.
+    # It also applies some limited parsing to the result values, mainly snakifying
+    # the property keys, and instantiating Rule objects if necessary.
+    #
+    # All properties of the struct are also available on a TimeSeries object itself
+    # via delegation.
+    #
+    # @!attribute [r] chunk_count
+    #   @return [Integer] number of memory chunks used for the time-series
+    # @!attribute [r] first_timestamp
+    #   @return [Integer] first timestamp present in the time-series (milliseconds since epoch)
+    # @!attribute [r] labels
+    #   @return [Hash] a hash of label-value pairs that represent metadata labels of the time-series
+    # @!attribute [r] last_timestamp
+    #   @return [Integer] last timestamp present in the time-series (milliseconds since epoch)
+    # @!attribute [r] max_samples_per_chunk
+    #   @return [Integer] maximum number of samples per memory chunk
+    # @!attribute [r] memory_usage
+    #   @return [Integer] total number of bytes allocated for the time-series
+    # @!attribute [r] retention_time
+    #   @return [Integer] retention time, in milliseconds, for the time-series.
+    #     A zero value means unlimited retention.
+    # @!attribute [r] rules
+    #   @return [Array<Rule>] an array of configured compaction {Rule}s
+    # @!attribute [r] series
+    #   @return [TimeSeries] the series this info is from
+    # @!attribute [r] source_key
+    #   @return [String, nil] the key of the source series, if this series is the destination
+    #     of a compaction rule
+    # @!attribute [r] total_samples
+    #   @return [Integer] the total number of samples in the series
+    #
+    # @see TimeSeries#info
+    # @see https://oss.redislabs.com/redistimeseries/commands/#tsinfo
     Info = Struct.new(
-      :series,
-      :total_samples,
-      :memory_usage,
-      :first_timestamp,
-      :last_timestamp,
-      :retention_time,
       :chunk_count,
-      :max_samples_per_chunk,
+      :first_timestamp,
       :labels,
-      :source_key,
+      :last_timestamp,
+      :max_samples_per_chunk,
+      :memory_usage,
+      :retention_time,
       :rules,
+      :series,
+      :source_key,
+      :total_samples,
       keyword_init: true
     ) do
+      # @api private
+      # @return [Info]
       def self.parse(series:, data:)
         data.each_slice(2).reduce({}) do |h, (key, value)|
           # Convert camelCase info keys to snake_case
@@ -26,6 +62,17 @@ class Redis
           parsed_hash['rules'] = parsed_hash['rules'].map { |d| Rule.new(source: series, data: d) }
           new(parsed_hash)
         end
+      end
+
+      alias count total_samples
+      alias length total_samples
+      alias size total_samples
+
+      # If this series is the destination of a compaction rule, returns the source series of the data.
+      # @return [TimeSeries, nil] the series referred to by {source_key}
+      def source
+        return unless source_key
+        @source ||= TimeSeries.new(source_key, redis: series.redis)
       end
     end
   end

--- a/lib/redis/time_series/rule.rb
+++ b/lib/redis/time_series/rule.rb
@@ -1,24 +1,46 @@
 # frozen_string_literal: true
 class Redis
   class TimeSeries
+    # A compaction rule applies an aggregation from a source series to a destination series.
+    # As data is added to the source, it will be aggregated based on any configured rule(s) and
+    # distributed to the correct destination(s).
+    #
+    # Compaction rules are useful to retain data over long time periods without requiring exorbitant
+    # amounts of memory and storage. For example, if you're collecting data on a minute-by-minute basis,
+    # you may want to retain a week's worth of data at full fidelity, and a year's worth of data downsampled
+    # to hourly, which would require 60x less memory.
     class Rule
-      attr_reader :source, :destination_key, :aggregation
+      # @return [Aggregation] the configured aggregation for this rule
+      attr_reader :aggregation
 
+      # @return [String] the Redis key of the destination series
+      attr_reader :destination_key
+
+      # @return [TimeSeries] the data source of this compaction rule
+      attr_reader :source
+
+      # Manually instantiating a rule does nothing, don't bother.
+      # @api private
+      # @see Info#rules
       def initialize(source:, data:)
         @source = source
         @destination_key, duration, aggregation_type = data
         @aggregation = Aggregation.new(aggregation_type, duration)
       end
 
+      # Delete this compaction rule.
+      # @return [String] the string "OK"
+      def delete
+        source.delete_rule(dest: destination_key)
+      end
+
+      # @return [TimeSeries] the destination time series this rule refers to
       def destination
         @dest ||= TimeSeries.new(destination_key, redis: source.redis)
       end
       alias dest destination
 
-      def delete
-        source.delete_rule(dest: destination_key)
-      end
-
+      # @return [String] the Redis key of the source series
       def source_key
         source.key
       end

--- a/lib/redis/time_series/sample.rb
+++ b/lib/redis/time_series/sample.rb
@@ -1,23 +1,39 @@
 # frozen_string_literal: true
 class Redis
   class TimeSeries
+    # A sample is an immutable value object that represents a single data point within a time series.
     class Sample
-      TS_FACTOR = 1000.0
+      using TimeMsec
 
-      attr_reader :time, :value
+      # @return [Time] the sample's timestamp
+      attr_reader :time
+      # @return [BigDecimal] the decimal value of the sample
+      attr_reader :value
 
+      # Samples are returned by time series query methods, there's no need to create one yourself.
+      # @api private
+      # @see TimeSeries#get
+      # @see TimeSeries#range
       def initialize(timestamp, value)
-        @time = Time.at(timestamp / TS_FACTOR)
+        @time = Time.from_msec(timestamp)
         @value = BigDecimal(value)
       end
 
-      def ts_msec
-        (time.to_f * TS_FACTOR).to_i
+      # @return [Integer] the millisecond value of the sample's timestamp
+      # @note
+      #   We're wrapping the method provided by the {TimeMsec} refinement for convenience,
+      #   otherwise it wouldn't be callable on {time} and devs would have to litter
+      #   +using TimeMsec+ or +* 1000.0+ wherever they wanted the value.
+      def to_msec
+        time.ts_msec
       end
 
+      # @return [Hash] a hash representation of the sample
+      # @example
+      #   {:timestamp=>1595199272401, :value=>0.2e1}
       def to_h
         {
-          timestamp: ts_msec,
+          timestamp: to_msec,
           value: value
         }
       end

--- a/spec/redis/time_series/sample_spec.rb
+++ b/spec/redis/time_series/sample_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Redis::TimeSeries::Sample do
     it { is_expected.to eq BigDecimal(value) }
   end
 
-  describe '#ts_msec' do
-    subject { sample.ts_msec }
+  describe '#to_msec' do
+    subject { sample.to_msec }
 
     it { is_expected.to be_an Integer }
     it { is_expected.to eq timestamp }

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe Redis::TimeSeries do
     it 'returns a Sample' do
       timestamp = ts.increment
       expect(ts.get).to be_a Redis::TimeSeries::Sample
-      expect(ts.get.ts_msec).to eq timestamp
+      expect(ts.get.to_msec).to eq timestamp
     end
   end
 
@@ -327,7 +327,7 @@ RSpec.describe Redis::TimeSeries do
       )
     end
 
-    Redis::TimeSeries::Info.members.each do |member|
+    (Redis::TimeSeries::Info.members - [:series]).each do |member|
       it "delegates ##{member} to #info" do
         expect(ts).to respond_to member
         expect(ts.public_send(member)).to eq ts.info.public_send(member)


### PR DESCRIPTION
Closes #4 

Adds YARD documentation to (most of) the gem, which will be available at https://rubydoc.info/gems/redis-time-series once the next release goes out.

I skipped a few places:
* `madd` commands, because I'm still not 100% sure about that interface
* `Filters` class, because it needs refactoring as per Codeclimate

Minor interface changes that probably aren't even worth mentioning:
* Renamed `Sample#ts_msec` to `Sample#to_msec`
* Added `Time.from_msec` to the `TimeMsec` refinement