### PR TITLE
Add support for endless ranges to TS.RANGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Add support for endless ranges to TS.RANGE (#50)
 * Cast label values to integers in Info struct (#49)
 * Build against edge upstream in addition to latest stable (#48)
 

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -312,12 +312,12 @@ class Redis
         # `range` will swallow all parameters if they're all hash syntax
         count = range.delete(:count)
         aggregation = range.delete(:aggregation)
-        range = range.fetch(:from)..range.fetch(:to)
+        range = range.fetch(:from)..range[:to]
       end
       cmd('TS.RANGE',
           key,
-          range.min,
-          range.max,
+          (range.begin || first_timestamp),
+          (range.end || last_timestamp),
           (['COUNT', count] if count),
           Aggregation.parse(aggregation)&.to_a
          ).map { |ts, val| Sample.new(ts, val) }

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -260,6 +260,15 @@ RSpec.describe Redis::TimeSeries do
       end
     end
 
+    context 'given an endless range' do
+      before { ts.add 123, to }
+
+      specify do
+        expect { ts.range from.., count: 10 }.to issue_command \
+          "TS.RANGE #{key} #{msec from} #{msec to} COUNT 10"
+      end
+    end
+
     context 'with a maximum result count' do
       specify do
         expect { ts.range from..to, count: 10 }.to issue_command \


### PR DESCRIPTION
`ts.range(1.hour.ago..)` will implicitly use the latest timestamp in the series to fill in the "end" value for the range.

Closes #41 