### PR TITLE
Add duplication policy to TS.CREATE and TS.ADD commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Add duplication policy to TS.CREATE and TS.ADD commands (#51)
 * Add support for endless ranges to TS.RANGE (#50)
 * Cast label values to integers in Info struct (#49)
 * Build against edge upstream in addition to latest stable (#48)

--- a/lib/redis-time-series.rb
+++ b/lib/redis-time-series.rb
@@ -1,9 +1,11 @@
 require 'bigdecimal'
 require 'forwardable'
 require 'ext/time_msec'
+
 require 'redis/time_series/client'
 require 'redis/time_series/errors'
 require 'redis/time_series/aggregation'
+require 'redis/time_series/duplicate_policy'
 require 'redis/time_series/filters'
 require 'redis/time_series/rule'
 require 'redis/time_series/info'

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -157,11 +157,19 @@ class Redis
     # @param value [Numeric] the value to add
     # @param timestamp [Time, Numeric] the +Time+, or integer timestamp in milliseconds, to add the value
     # @param uncompressed [Boolean] if true, stores data in an uncompressed format
+    # @param on_duplicate [String, Symbol] a duplication policy for conflict resolution
     #
     # @return [Sample] the value that was added
     # @raise [Redis::CommandError] if the value being added is older than the latest timestamp in the series
-    def add(value, timestamp = '*', uncompressed: nil)
-      ts = cmd 'TS.ADD', key, timestamp, value, ('UNCOMPRESSED' if uncompressed)
+    #
+    # @see TimeSeries::DuplicatePolicy
+    def add(value, timestamp = '*', uncompressed: nil, on_duplicate: nil)
+      ts = cmd 'TS.ADD',
+               key,
+               timestamp,
+               value,
+               ('UNCOMPRESSED' if uncompressed),
+               (DuplicatePolicy.new(on_duplicate).to_a('ON_DUPLICATE') if on_duplicate)
       Sample.new(ts, value)
     end
 

--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -37,6 +37,9 @@ class Redis
       #   With no value, the series will not be trimmed.
       # @option options [Boolean] :uncompressed
       #   When true, series data will be stored in an uncompressed format.
+      # @option options [String, Symbol] :duplicate_policy
+      #   A duplication policy to resolve conflicts when adding values to the series.
+      #   Valid values are in Redis::TimeSeries::DuplicatePolicy::VALID_POLICIES
       #
       # @return [Redis::TimeSeries] the created time series
       # @see https://oss.redislabs.com/redistimeseries/commands/#tscreate
@@ -165,10 +168,11 @@ class Redis
     # Issues a TS.CREATE command for the current series.
     # You should use class method {Redis::TimeSeries.create} instead.
     # @api private
-    def create(retention: nil, uncompressed: nil, labels: nil)
+    def create(retention: nil, uncompressed: nil, labels: nil, duplicate_policy: nil)
       cmd 'TS.CREATE', key,
           (['RETENTION', retention] if retention),
           ('UNCOMPRESSED' if uncompressed),
+          (DuplicatePolicy.new(duplicate_policy).to_a if duplicate_policy),
           (['LABELS', labels.to_a] if labels&.any?)
       self
     end

--- a/lib/redis/time_series/duplicate_policy.rb
+++ b/lib/redis/time_series/duplicate_policy.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+class Redis
+  class TimeSeries
+    # Duplication policies can be applied to a time series in order to resolve conflicts
+    # when adding data that already exists in the series.
+    #
+    # @see https://oss.redislabs.com/redistimeseries/master/configuration/#duplicate_policy
+    class DuplicatePolicy
+      VALID_POLICIES = %i[
+        block
+        first
+        last
+        min
+        max
+        sum
+      ].freeze
+
+      attr_reader :policy
+
+      def initialize(policy)
+        policy = policy.to_s.downcase.to_sym
+        if VALID_POLICIES.include?(policy)
+          @policy = policy
+        else
+          raise UnknownPolicyError, "#{policy} is not a valid duplicate policy"
+        end
+      end
+
+      def to_a(cmd = 'DUPLICATE_POLICY')
+        [cmd, policy]
+      end
+
+      def to_s(cmd = 'DUPLICATE_POLICY')
+        to_a(cmd).join(' ')
+      end
+
+      def ==(other)
+        return policy == other.policy if other.is_a?(self.class)
+        policy == self.class.new(other).policy
+      end
+
+      VALID_POLICIES.each do |policy|
+        define_method("#{policy}?") do
+          @policy == policy
+        end
+      end
+    end
+  end
+end

--- a/lib/redis/time_series/errors.rb
+++ b/lib/redis/time_series/errors.rb
@@ -15,5 +15,10 @@ class Redis
     # an unknown type, or when calling a command with an invalid aggregation value.
     # @see Redis::TimeSeries::Aggregation
     class AggregationError < Error; end
+
+    # +UnknownPolicyError+ is raised when attempting to apply an unkown type of
+    # duplicate policy when creating or adding to a series.
+    # @see Redis::TimeSeries::DuplicatePolicy
+    class UnknownPolicyError < Error; end
   end
 end

--- a/lib/redis/time_series/info.rb
+++ b/lib/redis/time_series/info.rb
@@ -78,6 +78,7 @@ class Redis
         end
 
         def transform_hash_values(hash, series)
+          hash[:duplicate_policy] = DuplicatePolicy.new(hash[:duplicate_policy]) if hash[:duplicate_policy]
           hash[:series] = series
           hash[:labels] = hash[:labels].to_h.transform_values { |v| v.to_i.to_s == v ? v.to_i : v }
           hash[:rules] = hash[:rules].map { |d| Rule.new(source: series, data: d) }

--- a/spec/redis/time_series/duplicate_policy_spec.rb
+++ b/spec/redis/time_series/duplicate_policy_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Redis::TimeSeries::DuplicatePolicy do
+  subject(:policy) { described_class.new(policy_key) }
+
+  let(:policy_key) { :block }
+
+  describe 'valid policies' do
+    specify do
+      expect(described_class::VALID_POLICIES).to match_array %i[
+        block first last min max sum
+      ]
+    end
+  end
+
+  describe '#initialize' do
+    context 'when given an unknown policy' do
+      let(:policy_key) { :foo }
+
+      it 'raises an error' do
+        expect { policy }.to raise_error Redis::TimeSeries::UnknownPolicyError
+      end
+    end
+
+    it 'accepts symbols' do
+      expect { described_class.new(:max) }.not_to raise_error
+    end
+
+    it 'accepts strings' do
+      expect { described_class.new('max') }.not_to raise_error
+    end
+
+    it 'case-insensitively parses' do
+      expect(described_class.new('MaX')).to eq described_class.new(:mAx)
+    end
+  end
+
+  describe '#to_a' do
+    it 'returns a command array' do
+      expect(policy.to_a).to eq ['DUPLICATE_POLICY', policy_key]
+    end
+
+    context 'when overriding the command key' do
+      it 'returns the correct array' do
+        expect(policy.to_a('ON_DUPLICATE')).to eq ['ON_DUPLICATE', policy_key]
+      end
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns a command string' do
+      expect(policy.to_s).to eq "DUPLICATE_POLICY #{policy_key}"
+    end
+
+    context 'when overriding the command key' do
+      it 'returns the correct string' do
+        expect(policy.to_s('ON_DUPLICATE')).to eq "ON_DUPLICATE #{policy_key}"
+      end
+    end
+  end
+
+  describe 'equality' do
+    specify 'to each other' do
+      expect(policy).to eq described_class.new(policy_key)
+    end
+
+    specify 'to strings' do
+      expect(policy).to eq policy_key.to_s
+    end
+
+    specify 'to symbols' do
+      expect(policy).to eq policy_key.to_sym
+    end
+  end
+
+  describe 'inquiry' do
+    specify { expect(policy).to be_block }
+    specify { expect(policy).not_to be_max }
+  end
+end

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe Redis::TimeSeries do
       end
     end
 
+    context 'with a duplication policy' do
+      let(:options) { { duplicate_policy: :max } }
+
+      specify do
+        expect { create }.to issue_command "TS.CREATE #{key} DUPLICATE_POLICY max"
+      end
+    end
+
     context 'with labels' do
       let(:options) { { labels: { foo: 'bar', baz: 1, plugh: true } } }
 

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -121,6 +121,10 @@ RSpec.describe Redis::TimeSeries do
       specify { expect { ts.add 123, uncompressed: true }.to issue_command "TS.ADD #{key} * 123 UNCOMPRESSED" }
     end
 
+    context 'with a duplication policy' do
+      specify { expect { ts.add 123, on_duplicate: :sum }.to issue_command "TS.ADD #{key} * 123 ON_DUPLICATE sum" }
+    end
+
     it 'returns the added Sample' do
       s = ts.add 123
       expect(s).to be_a Redis::TimeSeries::Sample


### PR DESCRIPTION
* `TimeSeries.create` now accepts a `duplicate_policy` argument.
* `TimeSeries#add` now accepts an `on_duplicate` argument.
* Valid values are in `Redis::TimeSeries::DuplicatePolicy::VALID_POLICIES`

Closes #43 