### PR TITLE
Update specs with CHUNK_SIZE value divisible by 8

### DIFF
--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -41,7 +41,8 @@ class Redis
       #   A duplication policy to resolve conflicts when adding values to the series.
       #   Valid values are in Redis::TimeSeries::DuplicatePolicy::VALID_POLICIES
       # @option options [Integer] :chunk_size
-      #   Amount of memory, in bytes, to allocate for each chunk of data
+      #   Amount of memory, in bytes, to allocate for each chunk of data. Must be a multiple
+      #   of 8. Default for a series is 4096.
       #
       # @return [Redis::TimeSeries] the created time series
       # @see https://oss.redislabs.com/redistimeseries/commands/#tscreate

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe Redis::TimeSeries do
     end
 
     context 'with a chunk size' do
-      let(:options) { { chunk_size: 123 } }
+      let(:options) { { chunk_size: 1024 } }
 
       specify do
-        expect { create }.to issue_command "TS.CREATE #{key} CHUNK_SIZE 123"
+        expect { create }.to issue_command "TS.CREATE #{key} CHUNK_SIZE 1024"
       end
     end
 
@@ -83,13 +83,13 @@ RSpec.describe Redis::TimeSeries do
           uncompressed: true,
           labels: { xyzzy: 'zork' },
           duplicate_policy: :max,
-          chunk_size: 123
+          chunk_size: 1024
         }
       end
 
       specify do
         expect { create }.to issue_command \
-          "TS.CREATE #{key} RETENTION 5678 UNCOMPRESSED CHUNK_SIZE 123 DUPLICATE_POLICY max LABELS xyzzy zork"
+          "TS.CREATE #{key} RETENTION 5678 UNCOMPRESSED CHUNK_SIZE 1024 DUPLICATE_POLICY max LABELS xyzzy zork"
       end
     end
   end
@@ -136,7 +136,7 @@ RSpec.describe Redis::TimeSeries do
     end
 
     context 'with a chunk size' do
-      specify { expect { ts.add 123, chunk_size: 456 }.to issue_command "TS.ADD #{key} * 123 CHUNK_SIZE 456" }
+      specify { expect { ts.add 123, chunk_size: 1024 }.to issue_command "TS.ADD #{key} * 123 CHUNK_SIZE 1024" }
     end
 
     it 'returns the added Sample' do
@@ -195,7 +195,7 @@ RSpec.describe Redis::TimeSeries do
     end
 
     context 'with a chunk size' do
-      specify { expect { ts.incrby 1, chunk_size: 456 }.to issue_command "TS.INCRBY #{key} 1 CHUNK_SIZE 456" }
+      specify { expect { ts.incrby 1, chunk_size: 2048 }.to issue_command "TS.INCRBY #{key} 1 CHUNK_SIZE 2048" }
     end
   end
 
@@ -211,7 +211,7 @@ RSpec.describe Redis::TimeSeries do
     end
 
     context 'with a chunk size' do
-      specify { expect { ts.decrby 1, chunk_size: 456 }.to issue_command "TS.DECRBY #{key} 1 CHUNK_SIZE 456" }
+      specify { expect { ts.decrby 1, chunk_size: 512 }.to issue_command "TS.DECRBY #{key} 1 CHUNK_SIZE 512" }
     end
   end
 


### PR DESCRIPTION
Per https://github.com/RedisTimeSeries/RedisTimeSeries/commit/404c552dcba3f2b1f47250eebb79020f63725727 the `CHUNK_SIZE` value must be a multiple of 8.