### PR TITLE
Add Ruby 3.1 to build matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         image_version: ['latest', 'edge']
-        ruby_version: ['2.6', '2.7', '3.0']
+        ruby_version: ['2.6', '2.7', '3.0', '3.1']
     services:
       redis:
         image: redislabs/redistimeseries:${{ matrix.image_version }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,6 +12,7 @@ jobs:
   spec:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         image_version: ['latest', 'edge']
         ruby_version: ['2.6', '2.7', '3.0', '3.1']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Add Ruby 3.1 to build matrix (#70)
 * Add Ruby 3.0 to build matrix (#63)
 * Relax Redis version constraint (#62)
 * Add TS.REVRANGE, TS.MRANGE, and TS.MREVRANGE commands (#19)


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/