### PR TITLE
Handle ActiveSupport::TimeWithZone objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Handle ActiveSupport::TimeWithZone objects (#75)
 
 ## 0.7.0
 * Add Ruby 3.1 to build matrix (#70)

--- a/lib/ext/time_msec.rb
+++ b/lib/ext/time_msec.rb
@@ -26,4 +26,12 @@ module TimeMsec
       at(timestamp / 1000.0)
     end
   end
+
+  if defined?(ActiveSupport::TimeWithZone)
+    refine ActiveSupport::TimeWithZone do
+      def ts_msec
+        utc.ts_msec
+      end
+    end
+  end
 end

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -123,6 +123,14 @@ RSpec.describe Redis::TimeSeries do
       end
     end
 
+    context 'with an ActiveSupport::TimeWithZone' do
+      let(:time) { ActiveSupport::TimeWithZone.new(Time.now, TZInfo::Timezone.get('Etc/UTC')) }
+
+      specify do
+        expect { ts.add 123, time }.to issue_command "TS.ADD #{key} #{time.strftime("%s%L")} 123"
+      end
+    end
+
     context 'with an invalid value' do
       specify { expect { ts.add 'bar' }.to raise_error Redis::CommandError }
     end


### PR DESCRIPTION
Because `ActiveSupport::TimeWithZone` [masquerades as a `Time`](https://github.com/rails/rails/blob/6-0-stable/activesupport/lib/active_support/time_with_zone.rb#L43), we need to refine that class as well with the millisecond serialization method.

Might be worth investigating an alternative implementation that doesn't use refinements.

Fixes #74 