### PR TITLE
Remove usage of Redis.current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Remove usage of `Redis.current` (#78)
 
 ## 0.7.2
 * Fix sample building for TS.MADD with multiple series (#77)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Or install it yourself as:
 
 Check out the Redis Time Series [command documentation](https://oss.redislabs.com/redistimeseries/master/commands/) first. Should be able to do most of that.
 
+### Configuring
+You can set the default Redis client for class-level calls operating on multiple series, as well as series created without specifying a client.
+```ruby
+Redis::TimeSeries.redis = Redis.new(url: ENV['REDIS_URL'], timeout: 1)
+```
+
 ### Creating a Series
 Create a series (issues `TS.CREATE` command) and return a Redis::TimeSeries object for further use. Key param is required, all other arguments are optional.
 ```ruby
@@ -58,7 +64,7 @@ ts = Redis::TimeSeries.create(
   labels: { foo: 'bar' },
   retention: 600,
   uncompressed: false,
-  redis: Redis.new(url: ENV['REDIS_URL']) # defaults to Redis.current
+  redis: Redis.new(url: ENV['REDIS_URL']) # defaults to Redis::TimeSeries.redis
 )
 ```
 You can also call `.new` instead of `.create` to skip the `TS.CREATE` command.

--- a/bin/setup
+++ b/bin/setup
@@ -10,7 +10,7 @@ require 'active_support/core_ext/numeric/time'
 require 'redis'
 require 'redis-time-series'
 
-Redis.current.flushall
+Redis.new.flushall
 ts1 = Redis::TimeSeries.create('ts1')
 ts2 = Redis::TimeSeries.create('ts2')
 ts3 = Redis::TimeSeries.create('ts3')

--- a/lib/redis/time_series/client.rb
+++ b/lib/redis/time_series/client.rb
@@ -42,9 +42,9 @@ class Redis
         @debug = !!bool
       end
 
-      # @return [Redis] the current Redis client. Defaults to +Redis.current+
+      # @return [Redis] the current Redis client. Defaults to +Redis.new+
       def redis
-        @redis ||= Redis.current
+        @redis ||= Redis.new
       end
 
       # Set the default Redis client for time series objects.

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Redis::TimeSeries do
   let(:from) { Time.at(time) }
   let(:to) { Time.at(time) + 120 }
 
-  after { Redis.current.del key }
+  after { redis.del key }
 
   def msec(ts)
     (ts.to_f * 1000).to_i
@@ -429,8 +429,8 @@ RSpec.describe Redis::TimeSeries do
     end
 
     after do
-      Redis.current.del 'ts1'
-      Redis.current.del 'ts2'
+      redis.del 'ts1'
+      redis.del 'ts2'
     end
 
     describe 'mrange' do
@@ -526,8 +526,8 @@ RSpec.describe Redis::TimeSeries do
     end
 
     after do
-      Redis.current.del 'good'
-      Redis.current.del 'bad'
+      redis.del 'good'
+      redis.del 'bad'
     end
 
     specify { expect { result }.to issue_command 'TS.QUERYINDEX foo=bar' }
@@ -566,25 +566,25 @@ RSpec.describe Redis::TimeSeries do
   end
 
   describe 'equality' do
-    let(:other_ts) { described_class.new(other_key, redis: redis) }
+    let(:other_ts) { described_class.new(other_key, redis: other_redis) }
 
     context 'when key and client match' do
       let(:other_key) { ts.key }
-      let(:redis) { ts.redis }
+      let(:other_redis) { ts.redis }
 
       it { is_expected.to eq other_ts }
     end
 
     context 'when key does not match' do
       let(:other_key) { 'other_key' }
-      let(:redis) { ts.redis }
+      let(:other_redis) { ts.redis }
 
       it { is_expected.not_to eq other_ts }
     end
 
     context 'when client does not match' do
       let(:other_key) { ts.key }
-      let(:redis) { Redis.new }
+      let(:other_redis) { Redis.new }
 
       it { is_expected.not_to eq other_ts }
     end


### PR DESCRIPTION
Remove usage of `Redis.current` in favor of instantiating a `Redis.new` client directly. At some point should add support for `ConnectionPool`.

Fixes #72 