### PR TITLE
Compatibility updates and spec fixes

### DIFF
--- a/lib/redis/time_series.rb
+++ b/lib/redis/time_series.rb
@@ -214,7 +214,7 @@ class Redis
           end
         else
           # single value, no timestamp
-          [key, '*', raw]
+          [[key, '*', raw]]
         end
       end
     end

--- a/lib/redis/time_series/client.rb
+++ b/lib/redis/time_series/client.rb
@@ -68,7 +68,7 @@ class Redis
       end
 
       def cmd_with_redis(redis, name, *args)
-        args = args.flatten.compact.map { |arg| arg.is_a?(Time) ? arg.ts_msec : arg }
+        args = args.flatten.compact.map { |arg| arg.is_a?(Time) ? arg.ts_msec : arg.to_s }
         puts "DEBUG: #{name} #{args.join(' ')}" if debug
         redis.call name, args
       end

--- a/spec/redis/time_series_spec.rb
+++ b/spec/redis/time_series_spec.rb
@@ -168,8 +168,15 @@ RSpec.describe Redis::TimeSeries do
       let(:time) { Time.now }
       let(:ts_msec) { time.to_i * 1000 }
 
-      before { travel_to time }
-      after { travel_back }
+      before do
+        %i[foo bar baz].each { |key| described_class.create(key) }
+        travel_to time
+      end
+
+      after do
+        %i[foo bar baz].each { |key| described_class.destroy(key) }
+        travel_back
+      end
 
       specify do
         expect { described_class.madd(foo: 1, bar: 2, baz: 3) }.to issue_command \
@@ -190,11 +197,9 @@ RSpec.describe Redis::TimeSeries do
       end
 
       it 'correctly returns samples' do
-        described_class.create(:foo)
         expect(described_class.madd(foo: { 123 => 1, 456 => 2 })).to all(
           be_a(Redis::TimeSeries::Sample)
         )
-        described_class.destroy(:foo)
       end
     end
   end


### PR DESCRIPTION
* Cast time series commands to string before sending to Redis.
Avoids error on implicit casting of `TrueClass`/`FalseClass`
* Pre-create time series keys for tests.
Previously was just testing the command, and ignoring errors. Those started raising.
* Correctly parse single-value arguments to `madd`
This was failing to return `Sample`s because the parsed argument list was a single-dimension array instead of multi-dimension