### PR TITLE
Allow filters to use any filter type

### DIFF
--- a/lib/redis/time_series/filters.rb
+++ b/lib/redis/time_series/filters.rb
@@ -124,7 +124,7 @@ class Redis
       end
 
       def valid?
-        !!filters.find { |f| f.is_a? Equal }
+        !!filters.find { |f| f.is_a?(Equal) || f.is_a?(AnyValue)}
       end
 
       def to_a


### PR DESCRIPTION
The docs mention the use of any of the following filter types:
```
{
  foo: 'bar',          # label=value  (equality)
  foo: { not: 'bar' }, # label!=value (inequality)
  foo: true,           # label=       (presence)
  foo: false,          # label!=      (absence)
  foo: [1, 2],         # label=(1,2)  (any value)
  foo: { not: [1, 2] } # label!=(1,2) (no values)
}
```
Validation rules prevent these type from being used.