### PR TITLE
Bump actions versions to v4

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -26,7 +26,7 @@ jobs:
       GIT_COMMIT_SHA: ${{ github.sha }}
       GIT_BRANCH: ${{ github.head_ref }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -44,7 +44,7 @@ jobs:
       run: bundle exec appraisal rake spec
     - name: Upload coverage report
       run: ./cc-test-reporter after-build -t simplecov coverage/.resultset.json
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: coverage/

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -46,5 +46,5 @@ jobs:
       run: ./cc-test-reporter after-build -t simplecov coverage/.resultset.json
     - uses: actions/upload-artifact@v4
       with:
-        name: coverage
+        name: coverage-${{ matrix.ruby_version }}-${{ matrix.image_version }}
         path: coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Add Ruby 3.2 to build matrix (#82)
+* Bump actions versions to v4 (#86)
 
 ## 0.8.0
 * Remove usage of `Redis.current` (#78)


### PR DESCRIPTION
Fixes node.js deprecation warnings on checkout and artifact actions

![Screenshot 2024-04-17 at 9 56 27 PM](https://github.com/dzunk/redis-time-series/assets/16783036/8f5610c0-cf1c-424b-ae0c-e70de69c69c9)
