### PR TITLE
Add Ruby 3.4 to build matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         image_version: ['latest', 'edge']
-        ruby_version: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby_version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
     services:
       redis:
         image: redislabs/redistimeseries:${{ matrix.image_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-* Add Ruby 3.4 to build matrix (#88)
+* Add Ruby 3.4 to build matrix (#89)
 
 ## 0.8.1
 * Add Ruby 3.2 to build matrix (#82)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Add Ruby 3.4 to build matrix (#88)
 
 ## 0.8.1
 * Add Ruby 3.2 to build matrix (#82)

--- a/redis-time-series.gemspec
+++ b/redis-time-series.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'redis', '>= 3.3'
 
-  spec.add_development_dependency 'activesupport', '~> 6.0'
+  spec.add_development_dependency 'activesupport', '~> 7.0'
   spec.add_development_dependency 'appraisal', '>= 2.5.0'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pry', '~> 0.13'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 SimpleCov.start { add_filter '/spec/' }
 
 require 'bundler/setup'
+require 'active_support'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/testing/time_helpers'
 require 'pry'


### PR DESCRIPTION
🎄 https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

Credit to [Steven Harman](https://stevenharman.net/cherry-picking-specific-active-support-behavior) on the change in how to `require` ActiveSupport 7+